### PR TITLE
maven walkmod plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,23 @@
 
     <build>
         <plugins>
+           <plugin>
+            <groupId>org.walkmod.maven.plugins</groupId>
+            <artifactId>walkmod-maven-plugin</artifactId>
+            <version>2.0</version>
+            <executions>
+              <execution>
+                <phase>process-classes</phase>
+                <goals>
+                  <goal>patch</goal>
+                </goals>
+                <configuration>
+                  <chains>checkstyle</chains>
+                  <properties>configurationFile=checkstyle.xml</properties>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
This patch adds the walkmod maven plugin. It is executed after
compiling classes because walkmod requires to resolve the application
classpath. If walkmod fixes any checkstyle issue (syntactic or
semantic), it will generate a walkmod.patch file.

Notice that formatting issues requires to use the Eclipse formatter and thus,
it is not focused on Checkstyle rules.

Fixes: https://github.com/walkmod/walkmod-core/issues/75